### PR TITLE
Process Management / Elimination of one click

### DIFF
--- a/LunaUpdater.csproj
+++ b/LunaUpdater.csproj
@@ -24,7 +24,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>1</ApplicationRevision>
+    <ApplicationRevision>2</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/LunaUpdater.csproj
+++ b/LunaUpdater.csproj
@@ -128,7 +128,7 @@
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6.1">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.6.1 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.6.1 %28x86 und x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">

--- a/LunaUpdater.csproj
+++ b/LunaUpdater.csproj
@@ -24,7 +24,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>2</ApplicationRevision>
+    <ApplicationRevision>1</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -128,7 +128,7 @@
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6.1">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.6.1 %28x86 und x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.6.1 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">

--- a/Program.cs
+++ b/Program.cs
@@ -40,9 +40,6 @@ namespace LunaUpdater
         static void Main(string[] args)
         {
             Process[] procList = Process.GetProcessesByName("LunaUpdater");
-            Process[] emuProcesses = Process.GetProcessesByName("Project64");
-
-            if(Process.GetProcessesByName("Project64").Length > 0) { foreach(Process proc in emuProcesses) { proc.Kill(); } }
             if (procList.Length != 1)
             {
                 return;

--- a/Program.cs
+++ b/Program.cs
@@ -48,13 +48,21 @@ namespace LunaUpdater
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
             string version = args.Count() == 0 ? null : args[0];
-            var form = MakeForm(version);
-            if (form == null)
+            try
             {
-                return;
-            }
+                var form = MakeForm(version);
+                if (form == null)
+                {
+                    return;
+                }
 
-            Application.Run(form);
+                Application.Run(form);
+
+            }
+            catch (Exception)
+            {
+                MessageBox.Show("The Update could not be installed :(\nReason: The Update could not be downloaded successfully", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -40,6 +40,9 @@ namespace LunaUpdater
         static void Main(string[] args)
         {
             Process[] procList = Process.GetProcessesByName("LunaUpdater");
+            Process[] emuProcesses = Process.GetProcessesByName("Project64");
+
+            if(Process.GetProcessesByName("Project64").Length > 0) { foreach(Process proc in emuProcesses) { proc.Kill(); } }
             if (procList.Length != 1)
             {
                 return;

--- a/UpdaterForm.Designer.cs
+++ b/UpdaterForm.Designer.cs
@@ -28,56 +28,57 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.labelUpdate = new System.Windows.Forms.Label();
-            this.buttonUpdate = new System.Windows.Forms.Button();
-            this.buttonIgnore = new System.Windows.Forms.Button();
-            this.SuspendLayout();
-            // 
-            // labelUpdate
-            // 
-            this.labelUpdate.AutoSize = true;
-            this.labelUpdate.Location = new System.Drawing.Point(13, 13);
-            this.labelUpdate.Name = "labelUpdate";
-            this.labelUpdate.Size = new System.Drawing.Size(134, 26);
-            this.labelUpdate.TabIndex = 0;
-            this.labelUpdate.Text = "An update is available!\r\nDo you want to download?";
-            // 
-            // buttonUpdate
-            // 
-            this.buttonUpdate.Location = new System.Drawing.Point(12, 51);
-            this.buttonUpdate.Name = "buttonUpdate";
-            this.buttonUpdate.Size = new System.Drawing.Size(75, 23);
-            this.buttonUpdate.TabIndex = 1;
-            this.buttonUpdate.Text = "Update";
-            this.buttonUpdate.UseVisualStyleBackColor = true;
-            this.buttonUpdate.Click += new System.EventHandler(this.buttonUpdate_Click);
-            // 
-            // buttonIgnore
-            // 
-            this.buttonIgnore.Location = new System.Drawing.Point(99, 51);
-            this.buttonIgnore.Name = "buttonIgnore";
-            this.buttonIgnore.Size = new System.Drawing.Size(75, 23);
-            this.buttonIgnore.TabIndex = 2;
-            this.buttonIgnore.Text = "Ignore";
-            this.buttonIgnore.UseVisualStyleBackColor = true;
-            this.buttonIgnore.Click += new System.EventHandler(this.buttonIgnore_Click);
-            // 
-            // UpdaterForm
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(186, 87);
-            this.Controls.Add(this.buttonIgnore);
-            this.Controls.Add(this.buttonUpdate);
-            this.Controls.Add(this.labelUpdate);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "UpdaterForm";
-            this.ShowIcon = false;
-            this.Text = "Luna Updater";
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.labelUpdate = new System.Windows.Forms.Label();
+			this.buttonUpdate = new System.Windows.Forms.Button();
+			this.buttonIgnore = new System.Windows.Forms.Button();
+			this.SuspendLayout();
+			// 
+			// labelUpdate
+			// 
+			this.labelUpdate.AutoSize = true;
+			this.labelUpdate.Location = new System.Drawing.Point(13, 13);
+			this.labelUpdate.Name = "labelUpdate";
+			this.labelUpdate.Size = new System.Drawing.Size(134, 26);
+			this.labelUpdate.TabIndex = 0;
+			this.labelUpdate.Text = "An update is available!\r\nDo you want to download?";
+			// 
+			// buttonUpdate
+			// 
+			this.buttonUpdate.Location = new System.Drawing.Point(12, 51);
+			this.buttonUpdate.Name = "buttonUpdate";
+			this.buttonUpdate.Size = new System.Drawing.Size(75, 23);
+			this.buttonUpdate.TabIndex = 1;
+			this.buttonUpdate.Text = "Update";
+			this.buttonUpdate.UseVisualStyleBackColor = true;
+			this.buttonUpdate.Click += new System.EventHandler(this.buttonUpdate_Click);
+			// 
+			// buttonIgnore
+			// 
+			this.buttonIgnore.Location = new System.Drawing.Point(99, 51);
+			this.buttonIgnore.Name = "buttonIgnore";
+			this.buttonIgnore.Size = new System.Drawing.Size(75, 23);
+			this.buttonIgnore.TabIndex = 2;
+			this.buttonIgnore.Text = "Ignore";
+			this.buttonIgnore.UseVisualStyleBackColor = true;
+			this.buttonIgnore.Click += new System.EventHandler(this.buttonIgnore_Click);
+			// 
+			// UpdaterForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(186, 87);
+			this.Controls.Add(this.buttonIgnore);
+			this.Controls.Add(this.buttonUpdate);
+			this.Controls.Add(this.labelUpdate);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "UpdaterForm";
+			this.ShowIcon = false;
+			this.Text = "Luna Updater";
+			this.Load += new System.EventHandler(this.UpdaterForm_Load);
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 

--- a/UpdaterForm.Designer.cs
+++ b/UpdaterForm.Designer.cs
@@ -28,57 +28,57 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.labelUpdate = new System.Windows.Forms.Label();
-			this.buttonUpdate = new System.Windows.Forms.Button();
-			this.buttonIgnore = new System.Windows.Forms.Button();
-			this.SuspendLayout();
-			// 
-			// labelUpdate
-			// 
-			this.labelUpdate.AutoSize = true;
-			this.labelUpdate.Location = new System.Drawing.Point(13, 13);
-			this.labelUpdate.Name = "labelUpdate";
-			this.labelUpdate.Size = new System.Drawing.Size(134, 26);
-			this.labelUpdate.TabIndex = 0;
-			this.labelUpdate.Text = "An update is available!\r\nDo you want to download?";
-			// 
-			// buttonUpdate
-			// 
-			this.buttonUpdate.Location = new System.Drawing.Point(12, 51);
-			this.buttonUpdate.Name = "buttonUpdate";
-			this.buttonUpdate.Size = new System.Drawing.Size(75, 23);
-			this.buttonUpdate.TabIndex = 1;
-			this.buttonUpdate.Text = "Update";
-			this.buttonUpdate.UseVisualStyleBackColor = true;
-			this.buttonUpdate.Click += new System.EventHandler(this.buttonUpdate_Click);
-			// 
-			// buttonIgnore
-			// 
-			this.buttonIgnore.Location = new System.Drawing.Point(99, 51);
-			this.buttonIgnore.Name = "buttonIgnore";
-			this.buttonIgnore.Size = new System.Drawing.Size(75, 23);
-			this.buttonIgnore.TabIndex = 2;
-			this.buttonIgnore.Text = "Ignore";
-			this.buttonIgnore.UseVisualStyleBackColor = true;
-			this.buttonIgnore.Click += new System.EventHandler(this.buttonIgnore_Click);
-			// 
-			// UpdaterForm
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(186, 87);
-			this.Controls.Add(this.buttonIgnore);
-			this.Controls.Add(this.buttonUpdate);
-			this.Controls.Add(this.labelUpdate);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "UpdaterForm";
-			this.ShowIcon = false;
-			this.Text = "Luna Updater";
-			this.Load += new System.EventHandler(this.UpdaterForm_Load);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.labelUpdate = new System.Windows.Forms.Label();
+            this.buttonUpdate = new System.Windows.Forms.Button();
+            this.buttonIgnore = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // labelUpdate
+            // 
+            this.labelUpdate.AutoSize = true;
+            this.labelUpdate.Location = new System.Drawing.Point(13, 13);
+            this.labelUpdate.Name = "labelUpdate";
+            this.labelUpdate.Size = new System.Drawing.Size(134, 26);
+            this.labelUpdate.TabIndex = 0;
+            this.labelUpdate.Text = "An update is available!\r\nDo you want to download?";
+            // 
+            // buttonUpdate
+            // 
+            this.buttonUpdate.Location = new System.Drawing.Point(12, 51);
+            this.buttonUpdate.Name = "buttonUpdate";
+            this.buttonUpdate.Size = new System.Drawing.Size(75, 23);
+            this.buttonUpdate.TabIndex = 1;
+            this.buttonUpdate.Text = "Update";
+            this.buttonUpdate.UseVisualStyleBackColor = true;
+            this.buttonUpdate.Click += new System.EventHandler(this.buttonUpdate_Click);
+            // 
+            // buttonIgnore
+            // 
+            this.buttonIgnore.Location = new System.Drawing.Point(99, 51);
+            this.buttonIgnore.Name = "buttonIgnore";
+            this.buttonIgnore.Size = new System.Drawing.Size(75, 23);
+            this.buttonIgnore.TabIndex = 2;
+            this.buttonIgnore.Text = "Ignore";
+            this.buttonIgnore.UseVisualStyleBackColor = true;
+            this.buttonIgnore.Click += new System.EventHandler(this.buttonIgnore_Click);
+            // 
+            // UpdaterForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(186, 87);
+            this.Controls.Add(this.buttonIgnore);
+            this.Controls.Add(this.buttonUpdate);
+            this.Controls.Add(this.labelUpdate);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "UpdaterForm";
+            this.ShowIcon = false;
+            this.Text = "Luna Updater";
+            this.Load += new System.EventHandler(this.UpdaterForm_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 

--- a/UpdaterForm.cs
+++ b/UpdaterForm.cs
@@ -95,5 +95,11 @@ namespace LunaUpdater
                 Close();
             }
         }
-    }
+
+		private void UpdaterForm_Load(object sender, EventArgs e)
+		{
+			Process[] emuProcesses = Process.GetProcessesByName("Project64");
+			if (Process.GetProcessesByName("Project64").Length > 0) { foreach (Process proc in emuProcesses) { proc.Kill(); } }
+		}
+	}
 }

--- a/UpdaterForm.cs
+++ b/UpdaterForm.cs
@@ -78,8 +78,22 @@ namespace LunaUpdater
                 buttonUpdate.Enabled = false;
                 buttonIgnore.Enabled = false;
                 labelUpdate.Text = $"Installing '{release_.TagName}'...";
-                await Task.Run(() => { ZipFile.ExtractToDirectory(tempFilePath_, AppDomain.CurrentDomain.BaseDirectory); });
+                await Task.Run(() =>
+                {
+                    using (ZipArchive archive = ZipFile.OpenRead(tempFilePath_))
+                    {
+                        foreach (ZipArchiveEntry entry in archive.Entries)
+                        {
+                            if (entry.Name == "Project64.exe")
+                            {
+                                entry.ExtractToFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, entry.Name), true);
+                            }
+                        }
+                    }
+                });
+                //await Task.Run(() => { ZipFile.ExtractToDirectory(tempFilePath_, AppDomain.CurrentDomain.BaseDirectory); });
                 MessageBox.Show("The update has been installed successfully!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                Process.Start("Project64.exe");
                 Close();
             }
         }

--- a/UpdaterForm.cs
+++ b/UpdaterForm.cs
@@ -99,7 +99,21 @@ namespace LunaUpdater
 		private void UpdaterForm_Load(object sender, EventArgs e)
 		{
 			Process[] emuProcesses = Process.GetProcessesByName("Project64");
-			if (Process.GetProcessesByName("Project64").Length > 0) { foreach (Process proc in emuProcesses) { proc.Kill(); } }
+			if (emuProcesses.Length > 0) 
+            { 
+                foreach (Process proc in emuProcesses) 
+                {
+                    try
+                    {
+                        proc.Kill();
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"The was an issue with installing the update :(\n{ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        Close();
+                    }
+                } 
+            }
 		}
 	}
 }

--- a/UpdaterForm.cs
+++ b/UpdaterForm.cs
@@ -40,9 +40,12 @@ namespace LunaUpdater
             {
                 File.Delete(tempFilePath_);
             }
-        }
+            if(File.Exists("Project64.exe"))
+			    Process.Start("Project64.exe");
 
-        private void buttonIgnore_Click(object sender, EventArgs e)
+		}
+
+		private void buttonIgnore_Click(object sender, EventArgs e)
         {
             Close();
         }
@@ -68,16 +71,10 @@ namespace LunaUpdater
                 labelUpdate.Text = $"Downloading an update '{release_.TagName}'...";
                 tempFilePath_ = await updater_.DownloadLatestRelease(release_);
                 labelUpdate.Text = $"Downloaded '{release_.TagName}' successfully!\nDo you want to install?";
-                buttonUpdate.Text = "Install";
-                buttonUpdate.Enabled = true;
-                buttonIgnore.Enabled = true;
                 BringSelfToForeGround();
-            }
-            else
-            {
-                buttonUpdate.Enabled = false;
-                buttonIgnore.Enabled = false;
+            
                 labelUpdate.Text = $"Installing '{release_.TagName}'...";
+                //If only wanting to extract Project64.exe from Zip-File
                 await Task.Run(() =>
                 {
                     using (ZipArchive archive = ZipFile.OpenRead(tempFilePath_))
@@ -91,9 +88,10 @@ namespace LunaUpdater
                         }
                     }
                 });
+                //If wanting to extract the entire Zip-file
+                //Need: A Zip-File where the root contains all the content so it can be easily extracted into the pj64 directory via overwrite
                 //await Task.Run(() => { ZipFile.ExtractToDirectory(tempFilePath_, AppDomain.CurrentDomain.BaseDirectory); });
                 MessageBox.Show("The update has been installed successfully!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                Process.Start("Project64.exe");
                 Close();
             }
         }


### PR DESCRIPTION
Every PJ64 Process Instance gets killed upon launching the Updater. After the Update is completed, PJ64 gets launched again.

Removed the step of confirming the update installation after downloading.

Adjusted the extraction step (see comments in the source code)